### PR TITLE
Make functions follow .arg convention

### DIFF
--- a/R/at-depth.R
+++ b/R/at-depth.R
@@ -59,7 +59,7 @@ at_depth <- function(.x, .depth, .f, ...) {
 
   recurse <- function(x, depth) {
     if (depth > 1) {
-      if (is.atomic(x) && depth >= 2) {
+      if (is.atomic(x)) {
         stop("List not deep enough", call. = FALSE)
       }
       lapply(x, recurse, depth = depth - 1)

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -3,8 +3,8 @@
 #' This is a wrapper for \code{\link{unlist}()} that defaults to
 #' \code{recursive = FALSE}.
 #'
-#' @param x A list of flatten
-#' @param recursive Recursively flatten list components?
+#' @param .x A list of flatten
+#' @param .recursive Recursively flatten list components?
 #' @export
 #' @examples
 #' x <- rerun(10, sample(5))
@@ -14,6 +14,6 @@
 #' x %>% map(~ .[1]) %>% flatten()
 #' # But it's better to use map_v
 #' x %>% map_v(~ .[1])
-flatten <- function(x, recursive = FALSE) {
-  unlist(x, recursive = recursive)
+flatten <- function(.x, .recursive = FALSE) {
+  unlist(.x, recursive = .recursive)
 }

--- a/R/rerun.R
+++ b/R/rerun.R
@@ -3,10 +3,10 @@
 #' This is a convenient way of generating sample data. It works similarly to
 #' \code{\link{replicate}(..., simplify = FALSE)}.
 #'
-#' @param n Number of times to run expressions
+#' @param .n Number of times to run expressions
 #' @param ... Expressions to re-run.
-#' @return A list of length \code{n}. Each element of \code{...} will be
-#'   re-run once for each \code{n}. It
+#' @return A list of length \code{.n}. Each element of \code{...} will be
+#'   re-run once for each \code{.n}. It
 #'
 #'   There is one special case: if there's a single unnamed input, the second
 #'   level list will be dropped. In this case, \code{rerun(n, x)} behaves like
@@ -17,10 +17,10 @@
 #' 10 %>%
 #'   rerun(x = rnorm(5), y = rnorm(5)) %>%
 #'   map_v(~ cor(.$x, .$y))
-rerun <- function(n, ...) {
+rerun <- function(.n, ...) {
   dots <- substitute(list(...))
 
-  out <- vector("list", n)
+  out <- vector("list", .n)
 
   # Special case: if single unnamed argument, insert directly into the output
   # rather than wrapping in a list.
@@ -28,7 +28,7 @@ rerun <- function(n, ...) {
     dots <- dots[[2]]
   }
 
-  for (i in seq_len(n)) {
+  for (i in seq_len(.n)) {
     out[[i]] <- eval(dots)
   }
 

--- a/R/zip.R
+++ b/R/zip.R
@@ -6,16 +6,16 @@
 #' and \code{b} that contained lists of length n.
 #'
 #' @param .x A list.
-#' @param fields Fields to use when unzipping - defaults to the names
+#' @param .fields Fields to use when unzipping - defaults to the names
 #'   of the first sub-list.
-#' @param simplify If \code{TRUE}, lists containing atomic scalars of the
+#' @param .simplify If \code{TRUE}, lists containing atomic scalars of the
 #'   same type will be converted to a vector.
 #' @export
 #' @examples
 #' x <- rerun(5, x = runif(1), y = runif(5))
 #' str(x)
 #' unzip(x)
-#' unzip(x, simplify = TRUE)
+#' unzip(x, .simplify = TRUE)
 #'
 #' zip(list(a = 1:5, b = 5:1))
 #' # unzip is similar to map2 used with list()
@@ -34,23 +34,23 @@ zip <- function(.x) {
 
 #' @export
 #' @rdname zip
-unzip <- function(.x, fields = NULL, simplify = TRUE) {
+unzip <- function(.x, .fields = NULL, .simplify = TRUE) {
   if (length(.x) == 0) return(list())
 
-  if (is.null(fields)) {
+  if (is.null(.fields)) {
     if (is.null(names(.x[[1]]))) {
-      fields <- seq_along(.x[[1]])
+      .fields <- seq_along(.x[[1]])
     } else {
-      fields <- setNames(names(.x[[1]]), names(.x[[1]]))
+      .fields <- setNames(names(.x[[1]]), names(.x[[1]]))
     }
   } else {
-    if (is.character(fields) && is.null(names(fields))) {
-      names(fields) <- fields
+    if (is.character(.fields) && is.null(names(.fields))) {
+      names(.fields) <- .fields
     }
   }
 
-  out <- lapply(fields, function(i) lapply(.x, .subset2, i))
-  if (simplify) out <- lapply(out, simplify_if_possible)
+  out <- lapply(.fields, function(i) lapply(.x, .subset2, i))
+  if (.simplify) out <- lapply(out, simplify_if_possible)
   out
 }
 

--- a/man/flatten.Rd
+++ b/man/flatten.Rd
@@ -4,12 +4,12 @@
 \alias{flatten}
 \title{Flatten a list of lists into a list.}
 \usage{
-flatten(x, recursive = FALSE)
+flatten(.x, .recursive = FALSE)
 }
 \arguments{
-\item{x}{A list of flatten}
+\item{.x}{A list of flatten}
 
-\item{recursive}{Recursively flatten list components?}
+\item{.recursive}{Recursively flatten list components?}
 }
 \description{
 This is a wrapper for \code{\link{unlist}()} that defaults to

--- a/man/rerun.Rd
+++ b/man/rerun.Rd
@@ -4,16 +4,16 @@
 \alias{rerun}
 \title{Re-run expressions multiple times.}
 \usage{
-rerun(n, ...)
+rerun(.n, ...)
 }
 \arguments{
-\item{n}{Number of times to run expressions}
+\item{.n}{Number of times to run expressions}
 
 \item{...}{Expressions to re-run.}
 }
 \value{
-A list of length \code{n}. Each element of \code{...} will be
-  re-run once for each \code{n}. It
+A list of length \code{.n}. Each element of \code{...} will be
+  re-run once for each \code{.n}. It
 
   There is one special case: if there's a single unnamed input, the second
   level list will be dropped. In this case, \code{rerun(n, x)} behaves like

--- a/man/zip.Rd
+++ b/man/zip.Rd
@@ -7,15 +7,15 @@
 \usage{
 zip(.x)
 
-unzip(.x, fields = NULL, simplify = TRUE)
+unzip(.x, .fields = NULL, .simplify = TRUE)
 }
 \arguments{
 \item{.x}{A list.}
 
-\item{fields}{Fields to use when unzipping - defaults to the names
+\item{.fields}{Fields to use when unzipping - defaults to the names
 of the first sub-list.}
 
-\item{simplify}{If \code{TRUE}, lists containing atomic scalars of the
+\item{.simplify}{If \code{TRUE}, lists containing atomic scalars of the
 same type will be converted to a vector.}
 }
 \description{
@@ -28,7 +28,7 @@ and \code{b} that contained lists of length n.
 x <- rerun(5, x = runif(1), y = runif(5))
 str(x)
 unzip(x)
-unzip(x, simplify = TRUE)
+unzip(x, .simplify = TRUE)
 
 zip(list(a = 1:5, b = 5:1))
 # unzip is similar to map2 used with list()


### PR DESCRIPTION
This replaces PR #37 where git history was messy.

I would also move `empty()` to objects.R and rename it to `is_empty()` if you're ok with that. `empty(list)` gives the impression that we are emptying a list rather than checking that it's empty.

I can also make the random generator functions and the type predicates follow the .arg convention. I felt like it would be weird for them to do so because they are completing or mimicking base R rather than being part of the functional programming tools. Naming is hard.